### PR TITLE
Really use maxDigits to align 6-7-8 codes' padding

### DIFF
--- a/main.go
+++ b/main.go
@@ -298,8 +298,8 @@ func (c *Keychain) showAll() {
 		if max < len(name) {
 			max = len(name)
 		}
-		if max < k.digits {
-			max = k.digits
+		if maxDigits < k.digits {
+			maxDigits = k.digits
 		}
 	}
 	sort.Strings(names)


### PR DESCRIPTION
`maxDigits` seems to be unused, so this quick patch fixes it to align entries with different code length.