### PR TITLE
Add auto-padding support

### DIFF
--- a/main.go
+++ b/main.go
@@ -314,6 +314,13 @@ func (c *Keychain) showAll() {
 }
 
 func decodeKey(key string) ([]byte, error) {
+	// auto-padding
+	mod := len(key) % 8
+
+	if mod != 0 {
+		key += strings.Repeat("=", (8 - mod))
+	}
+
 	return base32.StdEncoding.DecodeString(strings.ToUpper(key))
 }
 


### PR DESCRIPTION
Some services (like Fastmail, Vultr, mailbox.org and many others) generate not fully Base32-compliant codes.

This patch fixes it by adding auto-padding.