### PR TITLE
Add the packaging metadata to build the 2fa snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: 2fa
+version: git
+summary: Two-factor authentication agent
+description: |
+  2fa is a tool which provides two-factor authentication on the command line.
+grade: stable
+confinement: strict
+
+apps:
+  2fa:
+    command: 2fa
+
+parts:
+  2fa:
+    source: .
+    plugin: go
+    go-importpath: github.com/rsc/2fa


### PR DESCRIPTION
This package will let you publish the latest 2fa in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.

It was packaged by @konrad11901 during [google code-in](https://codein.withgoogle.com/).