### PR TITLE
Allow configuration of path to keychain file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The default time-based authentication codes are derived from a hash of the
 key and the current time, so it is important that the system clock have at
 least one-minute accuracy.
 
-The keychain is stored unencrypted in the text file `$HOME/.2fa`.
+The keychain is stored unencrypted in the text file `$HOME/.2fa` unless another
+path is provided via the `-keychain` parameter or the `KEYCHAIN` environment
+variable.
 
 ## Example
 


### PR DESCRIPTION
This adds the `-keychain` parameter to all commands which can be supplied a path
to where the user want 2fa to place the keychain and read it from.

The default value of `~/.2fa` can also be overruled by setting a path in the
environment variable named `KEYCHAIN`, so it doesn't have to be supplied on
every invocation.

Priority order is:

1. The `-keychain` argument.
2. The `KEYCHAIN` environment variable.
3. Default value of `~/.2fa`.