### PR TITLE
2fa: add -mv flag to rename key name

### DIFF
--- a/main.go
+++ b/main.go
@@ -328,6 +328,10 @@ func decodeKey(key string) ([]byte, error) {
 	return base32.StdEncoding.DecodeString(strings.ToUpper(key))
 }
 
+func encodeKey(raw []byte) string {
+	return base32.StdEncoding.EncodeToString(raw)
+}
+
 func hotp(key []byte, counter uint64, digits int) int {
 	h := hmac.New(sha1.New, key)
 	binary.Write(h, binary.BigEndian, counter)

--- a/main.go
+++ b/main.go
@@ -324,6 +324,21 @@ func (c *Keychain) showAll() {
 	}
 }
 
+func (c *Keychain) filePath() string {
+	fp := filepath.Join(os.Getenv("HOME"), ".2fa")
+	fi, err := os.Lstat(fp)
+	if err != nil {
+		log.Fatalf("keychain info: %v", err)
+	}
+	if fi.Mode().Type() == fs.ModeSymlink {
+		fp, err = os.Readlink(fp)
+		if err != nil {
+			log.Fatalf("keychain symlink: %v", err)
+		}
+	}
+	return fp
+}
+
 func decodeKey(key string) ([]byte, error) {
 	return base32.StdEncoding.DecodeString(strings.ToUpper(key))
 }


### PR DESCRIPTION
Summary of changes:

 - Add `encodeKey` function.
 - Add  `(*Keychain) filePath` method.
 - Add `-mv` flag to rename key name.