### PR TITLE
doc: use go install since go get is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Usage:
 
-    go get -u rsc.io/2fa
+    go install rsc.io/2fa@latest
 
     2fa -add [-7] [-8] [-hotp] name
     2fa -list


### PR DESCRIPTION
Hi,
 
I propose updating `README.md` to resolve following warning.

```
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
```

Thanks for the wonderful tool. I love it a lot.