### PR TITLE
README.md: replace `get -u` with `install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Usage:
 
-    go get -u rsc.io/2fa
+    go install rsc.io/2fa@latest
 
     2fa -add [-7] [-8] [-hotp] name
     2fa -list
@@ -56,4 +56,4 @@ Or to type less:
 
     $ 2fa
     268346	github
-    $ 
+    $


### PR DESCRIPTION
Running `go get -u` outside repo complains:

    go: go.mod file not found in current directory or any parent directory.
            'go get' is no longer supported outside a module.
            To build and install a command, use 'go install' with a version,
            like 'go install example.com/cmd@latest'
            For more information, see https://golang.org/doc/go-get-install-deprecation
            or run 'go help get' or 'go help install'.

Running it inside the repo simply updates `clipboard` module but does
not install the 2fa.

So use a `go install` instead.