### PR TITLE
when -clip is present do not print two-factor authentication code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+compilar.howto

--- a/main.go
+++ b/main.go
@@ -300,8 +300,9 @@ func (c *Keychain) show(name string) {
 	code := c.code(name)
 	if *flagClip {
 		clipboard.WriteAll(code)
+	} else {
+		fmt.Printf("%s\n", code)
 	}
-	fmt.Printf("%s\n", code)
 }
 
 func (c *Keychain) showAll() {

--- a/vendor/github.com/atotto/clipboard/.travis.yml
+++ b/vendor/github.com/atotto/clipboard/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+
+go:
+ - go1.4.3
+ - go1.5.4
+ - go1.6.4
+ - go1.7.6
+ - go1.8.7
+ - go1.9.4
+ - go1.10
+
+before_install:
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start
+
+script:
+ - sudo apt-get install xsel
+ - go test -v .
+ - sudo apt-get install xclip
+ - go test -v .

--- a/vendor/github.com/atotto/clipboard/README.md
+++ b/vendor/github.com/atotto/clipboard/README.md
@@ -1,0 +1,48 @@
+[![Build Status](https://travis-ci.org/atotto/clipboard.svg?branch=master)](https://travis-ci.org/atotto/clipboard)
+
+[![GoDoc](https://godoc.org/github.com/atotto/clipboard?status.svg)](http://godoc.org/github.com/atotto/clipboard)
+
+# Clipboard for Go
+
+Provide copying and pasting to the Clipboard for Go.
+
+Build:
+
+    $ go get github.com/atotto/clipboard
+
+Platforms:
+
+* OSX
+* Windows 7 (probably work on other Windows)
+* Linux, Unix (requires 'xclip' or 'xsel' command to be installed)
+
+
+Document: 
+
+* http://godoc.org/github.com/atotto/clipboard
+
+Notes:
+
+* Text string only
+* UTF-8 text encoding only (no conversion)
+
+TODO:
+
+* Clipboard watcher(?)
+
+## Commands:
+
+paste shell command:
+
+    $ go get github.com/atotto/clipboard/cmd/gopaste
+    $ # example:
+    $ gopaste > document.txt
+
+copy shell command:
+
+    $ go get github.com/atotto/clipboard/cmd/gocopy
+    $ # example:
+    $ cat document.txt | gocopy
+
+
+

--- a/vendor/github.com/atotto/clipboard/clipboard_windows.go
+++ b/vendor/github.com/atotto/clipboard/clipboard_windows.go
@@ -8,12 +8,13 @@ package clipboard
 
 import (
 	"syscall"
+	"time"
 	"unsafe"
 )
 
 const (
 	cfUnicodetext = 13
-	gmemFixed     = 0x0000
+	gmemMoveable  = 0x0002
 )
 
 var (
@@ -32,15 +33,31 @@ var (
 	lstrcpy      = kernel32.NewProc("lstrcpyW")
 )
 
+// waitOpenClipboard opens the clipboard, waiting for up to a second to do so.
+func waitOpenClipboard() error {
+	started := time.Now()
+	limit := started.Add(time.Second)
+	var r uintptr
+	var err error
+	for time.Now().Before(limit) {
+		r, _, err = openClipboard.Call(0)
+		if r != 0 {
+			return nil
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return err
+}
+
 func readAll() (string, error) {
-	r, _, err := openClipboard.Call(0)
-	if r == 0 {
+	err := waitOpenClipboard()
+	if err != nil {
 		return "", err
 	}
 	defer closeClipboard.Call()
 
 	h, _, err := getClipboardData.Call(cfUnicodetext)
-	if r == 0 {
+	if h == 0 {
 		return "", err
 	}
 
@@ -51,7 +68,7 @@ func readAll() (string, error) {
 
 	text := syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(l))[:])
 
-	r, _, err = globalUnlock.Call(h)
+	r, _, err := globalUnlock.Call(h)
 	if r == 0 {
 		return "", err
 	}
@@ -60,23 +77,30 @@ func readAll() (string, error) {
 }
 
 func writeAll(text string) error {
-	r, _, err := openClipboard.Call(0)
-	if r == 0 {
+	err := waitOpenClipboard()
+	if err != nil {
 		return err
 	}
 	defer closeClipboard.Call()
 
-	r, _, err = emptyClipboard.Call(0)
+	r, _, err := emptyClipboard.Call(0)
 	if r == 0 {
 		return err
 	}
 
 	data := syscall.StringToUTF16(text)
 
-	h, _, err := globalAlloc.Call(gmemFixed, uintptr(len(data)*int(unsafe.Sizeof(data[0]))))
+	// "If the hMem parameter identifies a memory object, the object must have
+	// been allocated using the function with the GMEM_MOVEABLE flag."
+	h, _, err := globalAlloc.Call(gmemMoveable, uintptr(len(data)*int(unsafe.Sizeof(data[0]))))
 	if h == 0 {
 		return err
 	}
+	defer func() {
+		if h != 0 {
+			globalFree.Call(h)
+		}
+	}()
 
 	l, _, err := globalLock.Call(h)
 	if l == 0 {
@@ -90,12 +114,15 @@ func writeAll(text string) error {
 
 	r, _, err = globalUnlock.Call(h)
 	if r == 0 {
-		return err
+		if err.(syscall.Errno) != 0 {
+			return err
+		}
 	}
 
 	r, _, err = setClipboardData.Call(cfUnicodetext, h)
 	if r == 0 {
 		return err
 	}
+	h = 0 // suppress deferred cleanup
 	return nil
 }

--- a/vendor/github.com/atotto/clipboard/go.mod
+++ b/vendor/github.com/atotto/clipboard/go.mod
@@ -1,0 +1,1 @@
+module github.com/atotto/clipboard

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,0 +1,3 @@
+# github.com/atotto/clipboard v0.1.2
+## explicit
+github.com/atotto/clipboard


### PR DESCRIPTION
If already copied into clipboard, there is no need to output two-factor authentication code and it can be pasted secretly elsewhere.